### PR TITLE
Add V2 save parser

### DIFF
--- a/test_v2parser.py
+++ b/test_v2parser.py
@@ -1,0 +1,30 @@
+import gzip
+import zlib
+from v2parser import parse_save
+
+
+def _write_gzip(path, text):
+    with gzip.open(path, 'wb') as fh:
+        fh.write(text.encode('utf-8'))
+
+
+def _write_zlib(path, text):
+    with open(path, 'wb') as fh:
+        fh.write(zlib.compress(text.encode('utf-8')))
+
+
+def test_parse_save_gzip(tmp_path):
+    content = 'player { name John score 10 } level 5'
+    p = tmp_path / 'save.v2'
+    _write_gzip(p, content)
+    assert parse_save(str(p)) == {
+        'player': {'name': 'John', 'score': '10'},
+        'level': '5',
+    }
+
+
+def test_parse_save_zlib(tmp_path):
+    content = 'outer { inner value }'
+    p = tmp_path / 'savez.v2'
+    _write_zlib(p, content)
+    assert parse_save(str(p)) == {'outer': {'inner': 'value'}}

--- a/v2parser.py
+++ b/v2parser.py
@@ -1,0 +1,65 @@
+"""Utilities for reading .v2 save files."""
+
+from __future__ import annotations
+
+import gzip
+import zlib
+import re
+from typing import Iterator, Dict, Any
+
+_token_pattern = re.compile(r'\{|\}|"[^"]*"|[^\s{}]+')
+
+
+def _decompress(data: bytes) -> str:
+    """Return UTF-8 text from gzipped or zlib-compressed data."""
+    if data[:2] == b"\x1f\x8b":
+        return gzip.decompress(data).decode("utf-8")
+    return zlib.decompress(data).decode("utf-8")
+
+
+def _tokenize(text: str) -> Iterator[str]:
+    for match in _token_pattern.finditer(text):
+        yield match.group(0)
+
+
+def _parse_tokens(tokens: Iterator[str]) -> Dict[str, Any]:
+    result: Dict[str, Any] = {}
+    key: str | None = None
+    for token in tokens:
+        if token == '}':
+            break
+        elif token == '{':
+            if key is None:
+                # Start of top-level block.
+                result.update(_parse_tokens(tokens))
+            else:
+                result[key] = _parse_tokens(tokens)
+                key = None
+        else:
+            value = token.strip('"')
+            if key is None:
+                key = value
+            else:
+                result[key] = value
+                key = None
+    return result
+
+
+def parse_save(path: str) -> Dict[str, Any]:
+    """Parse a compressed `.v2` save file into a dictionary.
+
+    Parameters
+    ----------
+    path: str
+        Path to the `.v2` file.
+
+    Returns
+    -------
+    dict
+        Nested representation of the file.
+    """
+    with open(path, 'rb') as fh:
+        data = fh.read()
+    text = _decompress(data)
+    tokens = ['{'] + list(_tokenize(text)) + ['}']
+    return _parse_tokens(iter(tokens))


### PR DESCRIPTION
## Summary
- parse .v2 files compressed with gzip or zlib
- convert brace-delimited plaintext to nested Python dicts
- test parsing for both compression formats

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a58af76e888325a1059bd89ef39e12