### PR TITLE
Add initial v2eco package with CLI utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# v2eco
+
+Minimal utilities for parsing and analyzing JSON payloads.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "v2eco"
+version = "0.1.0"
+description = "Utilities for parsing and analyzing data"
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+    "click",
+    "pydantic",
+]
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"

--- a/v2eco/__init__.py
+++ b/v2eco/__init__.py
@@ -1,0 +1,3 @@
+"""Core package for v2eco utilities."""
+
+__all__ = ["parser", "analyzer", "cli"]

--- a/v2eco/analyzer.py
+++ b/v2eco/analyzer.py
@@ -1,0 +1,12 @@
+"""Analysis helpers for processed data."""
+from __future__ import annotations
+
+from .parser import DataModel
+
+
+def analyze_data(model: DataModel) -> int:
+    """Perform a trivial analysis on ``DataModel``.
+
+    Currently returns the square of ``value`` to demonstrate functionality.
+    """
+    return model.value ** 2

--- a/v2eco/cli.py
+++ b/v2eco/cli.py
@@ -1,0 +1,20 @@
+"""Command line interface for v2eco."""
+from __future__ import annotations
+
+import click
+
+from .parser import parse_input
+from .analyzer import analyze_data
+
+
+@click.command()
+@click.argument("payload")
+def main(payload: str) -> None:
+    """Parse ``payload`` and print analysis result."""
+    model = parse_input(payload)
+    result = analyze_data(model)
+    click.echo(result)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/v2eco/parser.py
+++ b/v2eco/parser.py
@@ -1,0 +1,23 @@
+"""Parsing utilities using Pydantic models."""
+from __future__ import annotations
+
+from pydantic import BaseModel
+import json
+
+
+class DataModel(BaseModel):
+    """Simple data model representing input payload."""
+    name: str
+    value: int
+
+
+def parse_input(raw: str) -> DataModel:
+    """Parse a JSON string into a :class:`DataModel`.
+
+    Parameters
+    ----------
+    raw: str
+        JSON string containing ``name`` and ``value`` fields.
+    """
+    data = json.loads(raw)
+    return DataModel(**data)


### PR DESCRIPTION
## Summary
- add `v2eco` package with parsing, analysis, and CLI modules
- configure project metadata and dependencies via `pyproject.toml`
- ignore Python build artifacts

## Testing
- `PYTHONDONTWRITEBYTECODE=1 python -m py_compile v2eco/*.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a58ae317b88325b74314d864b97af6