### PR TITLE
Add mod file loader with state and good dataclasses

### DIFF
--- a/test_mod_io.py
+++ b/test_mod_io.py
@@ -1,0 +1,27 @@
+from v2eco.mod_io import load_mod
+
+
+def test_load_mod(tmp_path):
+    text = """
+    california = {
+        owner = USA
+        goods = {
+            grain = 10
+            timber = 5
+        }
+    }
+    texas = {
+        owner = MEX
+        goods = {
+            cotton = 8
+        }
+    }
+    """
+    p = tmp_path / "test.mod"
+    p.write_text(text)
+    states = load_mod(str(p))
+    assert len(states) == 2
+    ca = next(s for s in states if s.name == "california")
+    assert ca.owner == "USA"
+    grain = next(g for g in ca.goods if g.name == "grain")
+    assert grain.craftsmen == 10

--- a/v2eco/__init__.py
+++ b/v2eco/__init__.py
@@ -1,3 +1,3 @@
 """Core package for v2eco utilities."""
 
-__all__ = ["parser", "analyzer", "cli"]
+__all__ = ["parser", "analyzer", "cli", "models", "mod_io"]

--- a/v2eco/mod_io.py
+++ b/v2eco/mod_io.py
@@ -1,0 +1,97 @@
+"""Helpers for loading economic data from mod files.
+
+The parser understands a very small subset of the Paradox-style text
+format used by Victoria 2. The expected layout is::
+
+    STATE_NAME = {
+        owner = TAG
+        goods = {
+            GOOD_A = 10
+            GOOD_B = 5
+        }
+    }
+
+Each top-level key represents a state. ``=`` signs between keys and values
+are optional and ignored. Only the ``owner`` field and a ``goods`` block of
+``good = craftsmen`` pairs are interpreted. Anything else in the file is
+ignored.
+"""
+
+from __future__ import annotations
+
+from typing import Iterator, List
+from .models import State, Good
+import re
+
+_token_pattern = re.compile(r"\{|\}|\"[^\"]*\"|[^\s{}]+")
+
+
+def _tokenize(text: str) -> Iterator[str]:
+    """Yield meaningful tokens from ``text``.
+
+    The format optionally uses ``=`` between keys and values; these
+    separators are ignored so the downstream parser can operate on a
+    simple ``key value`` stream.
+    """
+    for match in _token_pattern.finditer(text):
+        token = match.group(0)
+        if token == "=":
+            continue
+        yield token
+
+
+def _parse_tokens(tokens: Iterator[str]) -> dict:
+    """Recursively parse tokens into a dictionary structure."""
+    result: dict = {}
+    key: str | None = None
+    for token in tokens:
+        if token == '}':
+            break
+        if token == '{':
+            if key is None:
+                result.update(_parse_tokens(tokens))
+            else:
+                result[key] = _parse_tokens(tokens)
+                key = None
+            continue
+        value = token.strip('"')
+        if key is None:
+            key = value
+        else:
+            result[key] = value
+            key = None
+    return result
+
+
+def load_mod(path: str) -> List[State]:
+    """Parse a mod file into :class:`State` objects.
+
+    Parameters
+    ----------
+    path:
+        Path to the mod definition file.
+
+    Returns
+    -------
+    list[State]
+        One :class:`State` per state block found in the file.
+    """
+    with open(path, 'r', encoding='utf-8') as fh:
+        text = fh.read()
+
+    tokens = ['{'] + list(_tokenize(text)) + ['}']
+    data = _parse_tokens(iter(tokens))
+    states: List[State] = []
+    for state_name, details in data.items():
+        owner = str(details.get('owner', ''))
+        goods_block = details.get('goods', {})
+        goods: List[Good] = []
+        if isinstance(goods_block, dict):
+            for g_name, craftsmen in goods_block.items():
+                try:
+                    craftsmen_int = int(craftsmen)
+                except (TypeError, ValueError):
+                    craftsmen_int = 0
+                goods.append(Good(name=g_name, craftsmen=craftsmen_int))
+        states.append(State(name=state_name, owner=owner, goods=goods))
+    return states

--- a/v2eco/models.py
+++ b/v2eco/models.py
@@ -1,0 +1,46 @@
+"""Data models for mod state economics.
+
+The :mod:`v2eco.models` module defines dataclasses representing ownership
+and goods production within a state. These are used by :func:`v2eco.mod_io.load_mod`
+to interpret mod files.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass
+class Good:
+    """A good produced within a state.
+
+    Attributes
+    ----------
+    name:
+        Identifier of the good.
+    craftsmen:
+        Number of craftsmen producing the good.
+    """
+
+    name: str
+    craftsmen: int
+
+
+@dataclass
+class State:
+    """Economic information for a state.
+
+    Attributes
+    ----------
+    name:
+        Name of the state as defined in the mod file.
+    owner:
+        Country tag owning the state.
+    goods:
+        Goods produced in the state with associated craftsmen counts.
+    """
+
+    name: str
+    owner: str
+    goods: List[Good]


### PR DESCRIPTION
## Summary
- add `State` and `Good` dataclasses for representing mod economic data
- implement `load_mod` to parse Paradox-style mod files into these models
- expose new modules in package and cover loader with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a61eed742883259feb3fb318958284