### PR TITLE
Add pop categories and soldier metrics

### DIFF
--- a/v2eco/__init__.py
+++ b/v2eco/__init__.py
@@ -1,3 +1,3 @@
 """Core package for v2eco utilities."""
 
-__all__ = ["parser", "analyzer", "cli"]
+__all__ = ["parser", "analyzer", "cli", "models", "io", "metrics"]

--- a/v2eco/cli.py
+++ b/v2eco/cli.py
@@ -5,6 +5,8 @@ import click
 
 from .parser import parse_input
 from .analyzer import analyze_data
+from .io import load_save_file
+from .metrics import soldier_count
 
 
 @click.command()
@@ -14,6 +16,15 @@ def main(payload: str) -> None:
     model = parse_input(payload)
     result = analyze_data(model)
     click.echo(result)
+
+
+@click.command()
+@click.argument("save_file")
+def analyze_cmd(save_file: str) -> None:
+    """Load ``save_file`` and print soldier counts per country."""
+    countries = load_save_file(save_file)
+    for country in countries:
+        click.echo(f"{country.name}: {soldier_count(country)}")
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/v2eco/io.py
+++ b/v2eco/io.py
@@ -1,0 +1,41 @@
+"""Input/output helpers for v2eco."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import List
+
+from .models import Country, Pop
+
+
+def load_save_file(path: str | Path) -> List[Country]:
+    """Load a simplified save file.
+
+    The file is expected to be JSON with structure::
+
+        {
+            "countries": [
+                {
+                    "name": "CountryName",
+                    "pops": [{"size": 10, "category": "laborer"}, ...]
+                },
+                ...
+            ]
+        }
+
+    Parameters
+    ----------
+    path:
+        Path to the JSON save file.
+    """
+    with open(path, "r", encoding="utf-8") as fh:
+        raw = json.load(fh)
+
+    countries: List[Country] = []
+    for cdata in raw.get("countries", []):
+        pops = [
+            Pop(size=p["size"], category=p.get("category", "laborer"))
+            for p in cdata.get("pops", [])
+        ]
+        countries.append(Country(name=cdata["name"], pops=pops))
+    return countries

--- a/v2eco/metrics.py
+++ b/v2eco/metrics.py
@@ -1,0 +1,15 @@
+"""Metrics helpers for v2eco."""
+from __future__ import annotations
+
+from .models import Country
+
+
+def soldier_count(country: Country) -> int:
+    """Return the total number of soldiers in ``country``.
+
+    Parameters
+    ----------
+    country:
+        Country for which to count pops with category ``"soldier"``.
+    """
+    return sum(pop.size for pop in country.pops if pop.category == "soldier")

--- a/v2eco/models.py
+++ b/v2eco/models.py
@@ -1,0 +1,29 @@
+"""Data models for v2eco."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass
+class Pop:
+    """Representation of a population unit.
+
+    Parameters
+    ----------
+    size:
+        Number of individuals in the pop.
+    category:
+        Type of pop such as ``"laborer"`` or ``"soldier"``.
+    """
+
+    size: int
+    category: str = "laborer"
+
+
+@dataclass
+class Country:
+    """Simple country model containing pops."""
+
+    name: str
+    pops: List[Pop] = field(default_factory=list)


### PR DESCRIPTION
## Summary
- add Pop and Country dataclasses including pop categories
- load optional pop category from save files with default laborer
- compute and display soldier counts per country via new CLI command

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a61eef30dc8325bb7c130231adbf57