### PR TITLE
Add factory employment metric and CLI example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
 # v2eco
 
 Minimal utilities for parsing and analyzing JSON payloads.
+
+## Command Line Usage
+
+The CLI exposes subcommands via ``python -m v2eco.cli``. To analyze a
+country's factory employment from a JSON file, run:
+
+```
+python -m v2eco.cli analyze sample_save.json
+```
+
+Example output:
+
+```
+Steel: 1200
+Textiles: 800
+Total: 2000
+```

--- a/sample_save.json
+++ b/sample_save.json
@@ -1,0 +1,7 @@
+{
+  "name": "Sampleland",
+  "industries": [
+    {"name": "Steel", "employees": 1200},
+    {"name": "Textiles", "employees": 800}
+  ]
+}

--- a/v2eco/__init__.py
+++ b/v2eco/__init__.py
@@ -1,3 +1,3 @@
 """Core package for v2eco utilities."""
 
-__all__ = ["parser", "analyzer", "cli"]
+__all__ = ["parser", "analyzer", "cli", "metrics"]

--- a/v2eco/cli.py
+++ b/v2eco/cli.py
@@ -1,19 +1,39 @@
 """Command line interface for v2eco."""
 from __future__ import annotations
 
+import json
 import click
 
 from .parser import parse_input
 from .analyzer import analyze_data
+from .metrics import Country, factory_employment
 
 
-@click.command()
+@click.group()
+def main() -> None:
+    """Entry point for v2eco commands."""
+
+
+@main.command("parse")
 @click.argument("payload")
-def main(payload: str) -> None:
+def parse_cmd(payload: str) -> None:
     """Parse ``payload`` and print analysis result."""
     model = parse_input(payload)
     result = analyze_data(model)
     click.echo(result)
+
+
+@main.command("analyze")
+@click.argument("path")
+def analyze_cmd(path: str) -> None:
+    """Print each industry's employees and country total from ``path``."""
+    with open(path) as fh:
+        data = json.load(fh)
+    country = Country(**data)
+    for ind in country.industries:
+        click.echo(f"{ind.name}: {ind.employees}")
+    total = factory_employment(country)
+    click.echo(f"Total: {total}")
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/v2eco/metrics.py
+++ b/v2eco/metrics.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+"""Metrics and models for v2eco."""
+
+from pydantic import BaseModel
+from typing import List
+
+
+class Industry(BaseModel):
+    """Representation of an industry within a country."""
+
+    name: str
+    employees: int
+
+
+class Country(BaseModel):
+    """Country holding multiple industries."""
+
+    name: str
+    industries: List[Industry] = []
+
+
+def factory_employment(country: Country) -> int:
+    """Return the total number of factory employees in ``country``."""
+
+    return sum(ind.employees for ind in country.industries)


### PR DESCRIPTION
## Summary
- add `Industry` and `Country` models with `factory_employment` metric
- show industry employment and totals via new `analyze` CLI command
- document sample usage with `sample_save.json`

## Testing
- `python -m v2eco.cli analyze sample_save.json`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a61ef019108325b2dbf02d98d092f6